### PR TITLE
Added testing framework. Refactored ProductList to separate concerns

### DIFF
--- a/graphQL-api/index.js
+++ b/graphQL-api/index.js
@@ -34,6 +34,6 @@ app.use('/graphql', bodyparser.json(), graphqlExpress({ schema: executableSchema
 app.use('/graphiql', graphiqlExpress({ endpointURL: '/graphql' }));
 
 // Start the server
-app.listen(3000, () => {
-  console.log('Go to http://localhost:3000/graphiql to run queries!');
+app.listen(4000, () => {
+  console.log('Go to http://localhost:4000/graphiql to run queries!');
 });

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "POC",
+  "name": "poc",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/react-app/.gitignore
+++ b/react-app/.gitignore
@@ -4,3 +4,4 @@ public/*.css
 **/.vscode/
 **/.DS_Store
 **/package-lock.json
+**/*.snap

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -7,13 +7,15 @@
     "build": "webpack",
     "dev": "webpack-dev-server -d --hot --config webpack.config.js",
     "prod": "NODE_ENV=production webpack",
-    "clean": "rm ./public/*.css & rm ./public/*.js & rm -rf ./public/images/"
+    "clean": "rm ./public/*.css & rm ./public/*.js & rm -rf ./public/images/",
+    "test": "jest --watchAll"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
     "babel-core": "^6.24.1",
+    "babel-jest": "^23.2.0",
     "babel-loader": "^7.0.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
@@ -22,10 +24,12 @@
     "extract-text-webpack-plugin": "^2.1.0",
     "file-loader": "^0.11.1",
     "image-webpack-loader": "^3.3.1",
+    "jest": "^23.2.0",
     "node-sass": "^4.5.3",
     "optimize-css-assets-webpack-plugin": "^1.3.2",
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4",
+    "react": "^16.4.1",
+    "react-dom": "^16.4.1",
+    "react-test-renderer": "^16.4.1",
     "sass-loader": "^6.0.5",
     "style-loader": "^0.18.1",
     "uglifyjs-webpack-plugin": "^0.4.3",
@@ -39,6 +43,8 @@
     "graphql": "^0.13.2",
     "graphql-tag": "^2.9.2",
     "isomorphic-fetch": "^2.2.1",
-    "react-apollo": "^2.1.6"
+    "react-apollo": "^2.1.6",
+    "unfetch": "^3.0.0",
+    "waait": "^1.0.2"
   }
 }

--- a/react-app/src/assets/components/ProductList/ProductQuery.jsx
+++ b/react-app/src/assets/components/ProductList/ProductQuery.jsx
@@ -7,8 +7,6 @@ export class ProductsQuery extends React.Component {
 
   render() {
     const { isLoading, isEmpty, isError, products, children } = this.props;
-    // return this.props.children(this.props.data)
-    // return <div> I am but a test</div>
     return children && children(products, { isLoading, isEmpty, isError });
   }
 }

--- a/react-app/src/assets/components/ProductList/ProductQuery.jsx
+++ b/react-app/src/assets/components/ProductList/ProductQuery.jsx
@@ -1,0 +1,27 @@
+import React from "react";
+import * as productData from "../../../services/graphDataService";
+import { graphql } from "react-apollo";
+
+export class ProductsQuery extends React.Component {
+
+
+  render() {
+    const { isLoading, isEmpty, isError, products, children } = this.props;
+    // return this.props.children(this.props.data)
+    // return <div> I am but a test</div>
+    return children && children(products, { isLoading, isEmpty, isError });
+  }
+}
+
+const mapDataToProps = ({ data }) => {
+  const isLoading = data.loading;
+  const isEmpty = !!data.products && data.products.length === 0;
+  const isError = !!data.error;
+  const products = data.products || [];
+
+  return { isLoading, isEmpty, isError, products };
+};
+
+export default graphql(productData.GETPRODUCTSQUERY, {
+  props: mapDataToProps
+})( ProductsQuery );

--- a/react-app/src/assets/components/ProductList/productList.jsx
+++ b/react-app/src/assets/components/ProductList/productList.jsx
@@ -1,44 +1,44 @@
-import React from "react"
-import * as productData from "../../../services/graphDataService"
-import { Query } from 'react-apollo'
-import styles from './styles'
+import React from "react";
+import ProductQuery from "./ProductQuery";
 
-// data.addProduct({id:9, name: "Ninety Nine Problems", shortDescription: "You know what ain't one."})
-
-const Product = props => {
+export const Product = props => {
   return (
     <div className="product">
       {props.name} - {props.shortDescription}
     </div>
-  )
-}
+  );
+};
 
-
-const ProductList = (props) =>  {
+const ProductList = props => {
   return (
-    <Query query={productData.GETPRODUCTSQUERY}>
-      {({loading, error, data}) => {
-        if (loading) return <p>Loading</p>
+    <ProductQuery>
+      {(products, { isLoading, isEmpty, isError }) => {
+        if (isLoading) {
+          return <div>Loading</div>;
+        }
 
-        if (error) return <p>Error: {JSON.stringify(error)}</p>
+        if (isEmpty) {
+          return <div>No items match your postal code</div>;
+        }
+
+        if (isError) {
+          return <div>There was an error processing your search</div>;
+        }
 
         return (
-            <ul>
-              {
-                data.products.map(((p, key) =>
-                  <li key={key} className="product-item">
-                    <Product
-                      id={p.id}
-                      name={p.name}
-                      shortDescription={p.shortDescription}
-                    />
-                  </li>))
-              }
-            </ul>
-            )
-        }
-      }
-    </Query>)
-}
-
-export default ProductList
+          <ul>
+            {products.map(product => (
+              <li key={product.id}>
+                <Product
+                  name={product.name}
+                  shortDescription={product.shortDescription}
+                />{" "}
+              </li>
+            ))}
+          </ul>
+        );
+      }}
+    </ProductQuery>
+  );
+};
+export default ProductList;

--- a/react-app/src/assets/components/ProductList/productList.test.jsx
+++ b/react-app/src/assets/components/ProductList/productList.test.jsx
@@ -1,0 +1,38 @@
+import "unfetch/polyfill"
+
+import wait from 'waait'
+import React from "react"
+import ProductList, { Product } from "./productList"
+import renderer from "react-test-renderer"
+import { MockedProvider } from "react-apollo/test-utils"
+import * as productData from "../../../services/graphDataService"
+
+
+const mocks = [
+  {
+    request: {
+      query: productData.GETPRODUCTSQUERY,
+      variables: {}
+    },
+    result: {
+      data: {
+        products: {
+          id: "1",
+          name: "Product 1",
+          shortDescription: "I am a product."
+        }
+      }
+    }
+  }
+]
+
+test("Can render a product", async () => {
+
+  const component = renderer.create(
+    <MockedProvider mocks={mocks} addTypename={false}>
+      <ProductList />
+    </MockedProvider>
+  )
+
+  await wait(0)
+})


### PR DESCRIPTION
- Returns GraphQL port to 4000
- fixes warning in package.json for overall project
- ignoring snapshots that are generated by testing framework
- Refactored Product List to separate query from presentation.